### PR TITLE
Remove unnecessary CORS header response

### DIFF
--- a/webtask/update_user_profile.js
+++ b/webtask/update_user_profile.js
@@ -20,13 +20,6 @@ app.use( jwt({ secret: function(req, payload, done){
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(function(req, res, next) {
-  res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
-
-  next();
-});
 
 app.use(function(req, res, next) {
   if (req.method.toLowerCase() === 'options') {


### PR DESCRIPTION
The Webtask infrastructure automatically responds with CORS headers when an `Origin` request header is passed.